### PR TITLE
Document decision to use IAM authentication for admins

### DIFF
--- a/adr/ADR015-aws-iam-authentication.md
+++ b/adr/ADR015-aws-iam-authentication.md
@@ -1,0 +1,25 @@
+# ADR015: AWS IAM Authentication (for admins)
+
+## Status
+
+Accepted
+
+## Context
+
+IAM Roles that can be assumed by authorized infrastructure engineers currently do not give access to the clusters via kubectl. We do not want to have to manage two sets of admins.
+
+## Decision
+
+We will enable any admin-like roles within the cluster only to those who can authenicate via the [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) assuming an appropriate role within the AWS account.
+
+This should provide:
+
+* Auditing to CloudTrial of authentication attempts and more
+* Single place to manage roles
+* A way to enable MFA/policy for cluster access
+* A better user-experience for accessing clusters (with help from aws-vault)
+* Simpler distribution of cluster configs (kubeconfig not containing anything sensitive)
+
+## Consequences
+
+* Requires installation of additional binary


### PR DESCRIPTION
IAM auth gives a better UX and is more managable and auditable than cert
based access or passing around a kubeconfig... this documents that we
are using it for our power-user accounts like admins