### PR TITLE
Add first draft of Shared Responsiblity Document to team manual

### DIFF
--- a/docs/gsp-shared-responsiblity-model.md
+++ b/docs/gsp-shared-responsiblity-model.md
@@ -1,0 +1,115 @@
+# GDS Supported Platform (GSP) shared responsibility
+
+TechOps (including Reliability Engineering, Cyber Security and User Support) uses a [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) to provide a supported platform to GDS product teams. Broadly, TechOps builds, runs and maintains the infrastructure, while the product teams maintain the applications that they wish to run on the platform.
+
+TechOps is only responsible for internal GDS product teams who host their service on the [GSP](https://github.com/alphagov/gsp-team-manual).
+
+## TechOps' responsibilities
+
+If you experience problems with the GSP, contact us using the [#techops Slack channel](https://gds.slack.com/messages/CBBK73196).
+
+[something probably needs to go in here about Zendesk?]
+
+### Provisioning Amazon Web Services (AWS) accounts and infrastructure
+
+When a team has decided to use the GSP for hosting their application or service, Reliability Engineering will create an AWS account for the team (unless one exists for their umbrella programme) and provision the underlying infrastructure for teams to deploy their app.
+
+### Updates and upgrades
+
+When infrastructural components need to be upgraded/updated, Reliability Engineering (RE) will do so for each team's infrastructure. This may happen often and will rarely impact the service or their users, so RE will not notify the service team before performing the upgrade/update unless there will be a discernible impact.
+
+### Logging, monitoring and alerting
+
+TechOps will provide logging, monitoring and alerting for the GSP. We will work with teams to ensure that it is setup in the most useful way for teams. Specifically:
+
+RE will ship logs to CloudWatch for further distribution. These logs will include:
+
+- [insert log types here]
+
+Cyber Security will then work with teams to establish use cases for the [Cloud Security Watch](#link) service that they provide. Cloud Security Watch will alert service teams when these use cases are triggered. This alert will include helpful information as to how the service team should deal with the situation.
+
+If the service team is unable to respond to the situation themselves, they should contact the Cyber Security team either [on Slack](https://gds.slack.com/messages/CCMPJKFDK) or through the [out-of-hours procedure](#link), if necessary.
+
+Cyber Security will also provide access to [Splunk](https://www.splunk.com/) and training for its use by service teams. Service teams will then be able to use Splunk for further monitoring.
+
+If, when dealing with service issues, security events/incidents, etc., service teams identify infrastructural issues, TechOps (RE or Cyber Security, depending on where the issue occurs) will work with the service team to rectify the issue.
+
+Due to the way in which applications are deployed and the production of logs occurs, TechOps will not be responsible for the structuring of logs or consistent identification of log streams (see *Logging* section in *Product team responsibilities* below).
+
+TechOps will provide monitoring, using [Prometheus](), and alerting, using [AlertManager]() and [PagerDuty]().
+
+TechOps will work with teams to identify the most valuable things to monitor and alert on (including the above Cloud Security Watch offering) and then to implement the correct logging, monitoring and alerting to facilitate this.
+
+TechOps will setup monitoring and alerting to ensure that we provide reliable and secure infrastructure, in line with our [Service Level Objectives]().
+
+[I think maybe this needs to be split out into separate "logging" and "monitoring and alerting" sections, but I don't know how...]
+
+### Cyber Security and acting on vulnerabilities
+
+Reliability Engineering will monitor [CVEs](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) that relate to the technologies that underpin the infrastructure that we provide. We will then mitigate any identified vulnerabilities with [THIS PERIOD OF TIME].
+
+Cyber Security will provide tooling and advice to teams, in order that they can identify and act upon security events and incidents. Tooling includes [Cloud Security Watch](https://github.com/alphagov/csw-infra) and [Splunk](https://www.splunk.com/). Advice includes working with teams to identify possible vulnerabilities that need to be monitored for exploitation, and then helping to set up that monitoring/alerting.
+
+### User management
+
+TechOps will control access to the underlying infrastructure using [AWS]() [IAM roles](). [some other stuff here]
+
+## Product team responsibilities
+
+### Updates and upgrades
+
+Product teams will be responsible for any updates/upgrades to the application and any upstream dependencies (such as libraries and packages).
+
+TechOps will, however, make this as easy as possible to implement, as changes such as these can be made live by making the changes in the code base before merging them to the master branch of the repository.
+
+### Logging
+
+Product teams are responsible for ensuring that they configure their applications and Docker images to ship logs [link to guidance?].
+
+They must also ensure that their logs have a sensible and logical structure, to make them easy to identify and filter. For example:
+
+[insert example of logically structured logs or link to guidance]
+
+Similarly, product teams must name their containers sensibly and logically for consistent identification of log streams. For example:
+
+[insert example of logically named containers or link to guidance]
+
+### Monitoring and responding to alerts
+
+It is the product team's responsibility to monitor their product/service (using tooling provided by TechOps - see above) and to respond to both monitoring and alerts as required.
+
+The product team is also expected to allocate time to defining Service Level Indicators (SLIs) and Objectives (SLOs), in order that we can collectively setup the correct monitoring and alerting.
+
+### User management
+
+You must ensure that you control access to GitHub. As any code that is merged to the master branch of a repository will automatically be deployed, it is vital that only [trusted individuals](link to GDS Way bit about SC clearance and stuff) are able to merge pull requests.
+
+### [What of the following (if any) will we do vs. what the service team should do?]
+
+You must secure your AWS infrastructure. For example:
+
+* control egress traffic by [implementing VPC egress controls](https://aws.amazon.com/answers/networking/controlling-vpc-egress-traffic/)
+* use [TLS and other secure protocols](https://www.ncsc.gov.uk/guidance/tls-external-facing-services) to protect data
+* use secure coding practices like peer review
+* secure developer machines - ask the GDS IT team for guidance
+* manage secrets to [secure the build and deployment pipeline](https://www.ncsc.gov.uk/guidance/secure-build-and-deployment-pipeline)
+* control access to provisioned machines and other AWS services
+* implement protective monitoring and [logging for security purposes](https://www.ncsc.gov.uk/guidance/introduction-logging-security-purposes)
+* use [security hardening for VMs](https://gds-way.cloudapps.digital/standards/operating-systems.html)
+* enabling infrastructure monitoring using [AWS CloudWatch](https://aws.amazon.com/cloudwatch/)
+
+You must [transfer ownership](https://github.com/alphagov/re-build-systems/blob/master/examples/gds_specific_dns_and_jenkins/README.md#provision-the-main-jenkins-infrastructure) of the OAuth app to the [GitHub alphagov organisation](https://github.com/alphagov) once you have provisioned Jenkins. This prevents unauthorised access to the build system if the owner of the OAuth app leaves GDS.
+
+## Third party responsibilities
+
+Third party providers are responsible for making sure their systems are updated and available.
+
+### Amazon
+
+Amazon maintains the AWS infrastructure and is responsible for updating it. Reliability Engineering and product teams do not need to update or upgrade AWS.
+
+### Docker.io
+
+When you provision or reprovision your infrastructure you use the latest version of Docker. Docker is responsible for the maintenance and support of new and current versions.
+
+### [any others explicitly?]

--- a/docs/gsp-shared-responsiblity-model.md
+++ b/docs/gsp-shared-responsiblity-model.md
@@ -1,58 +1,108 @@
 # GDS Supported Platform (GSP) shared responsibility
 
-TechOps (including Reliability Engineering, Cyber Security and User Support) uses a [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) to provide a supported platform to GDS product teams. Broadly, TechOps builds, runs and maintains the infrastructure, while the product teams maintain the applications that they wish to run on the platform.
+TechOps (including Reliability Engineering, Cyber Security and User Support) uses a [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) to provide a supported platform to GDS product teams. Broadly, TechOps builds, runs and maintains the infrastructure and supporting services, while the product teams maintain the applications that they wish to run on the platform.
 
-TechOps is only responsible for internal GDS product teams who host their service on the [GSP](https://github.com/alphagov/gsp-team-manual).
+TechOps is only responsible for internal GDS product teams who host their service on the [GDS Supported Platform](https://github.com/alphagov/gsp-team-manual) and the [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk/).
+
+## Summary of responsibilities
+
+| Activity | Product team | Reliability Engineering | Cyber Security |
+| -------- | -------- | -------- | -------- |
+| Provide account (e.g. AWS, PagerDuty, Alert Manager)     |  | ✓ |  |
+| Provide account (e.g. Splunk)     |  |  | ✓ |  
+| Create build/deploy pipeline     | ✓ | ✓* |  |
+| Respond to incidents     | ✓ | ✓** | ✓** |
+| Respond to other alerts     | ✓ | ✓** |  |
+| Set up infrastructure |  | ✓ |  |
+| Maintain infrastructure     |  | ✓ |  |
+| Maintain product/application(s) | ✓ |  |  |
+| Set up & structure logging | ✓ | ✓* | ✓* |
+| Provide tooling for logging |  | ✓ | ✓ |
+| Monitor the reliability of key user journeys (SLIs) | ✓ | ✓* |  |
+| Set shared reliability goals for each SLI (SLOs) |✓ | ✓ |  |
+| Agree on policy for breaking SLOs |✓ | ✓ |  |
+
+\* = in a supporting role/through documentation
+** = if called upon / if the main team can’t deal with the situation
 
 ## TechOps' responsibilities
 
-If you experience problems with the GSP, contact us using the [#techops Slack channel](https://gds.slack.com/messages/CBBK73196).
+If you (a product team) experience problems with the GDS Supported Platform, contact us using the [#techops](https://gds.slack.com/messages/CBBK73196) Slack channel.
 
-[something probably needs to go in here about Zendesk?]
+Contact Cyber Security using the [#cyber-security-help](https://gds.slack.com/messages/CCMPJKFDK) Slack channel.
 
 ### Provisioning Amazon Web Services (AWS) accounts and infrastructure
 
-When a team has decided to use the GSP for hosting their application or service, Reliability Engineering will create an AWS account for the team (unless one exists for their umbrella programme) and provision the underlying infrastructure for teams to deploy their app.
+When a team has decided to use the GDS Supported Platform for hosting their application or service, Reliability Engineering (RE) will create an AWS account for the team (unless one exists for their wider programme, for example, GOV.UK or GOV.UK Verify) and provision the underlying infrastructure for teams to deploy their app.
 
 ### Updates and upgrades
 
-When infrastructural components need to be upgraded/updated, Reliability Engineering (RE) will do so for each team's infrastructure. This may happen often and will rarely impact the service or their users, so RE will not notify the service team before performing the upgrade/update unless there will be a discernible impact.
+When infrastructural components need to be upgraded/updated, RE will do so for each team's infrastructure. This may happen often and will rarely impact the service or their users, so RE will not notify the service team before performing the upgrade/update unless there will be a discernible impact.
+
+### Setting up a build/deploy pipeline
+
+Reliability Engineering will help teams to set up a build and deployment pipeline (otherwise known as a continuous integration and deployment (CI/CD) pipeline) as part of helping teams migrate to either the PaaS or the GSP.
+
+This includes providing the tooling and documentation for product teams, as well as consulting/working with teams to get an initial pipeline setup.
+
+RE will always be available on a consultant basis, should product teams need help.
+
+RE is also responsible for providing tooling to monitor the pipeline, for example to monitor the progress (and success/failure) of jobs that are running.
 
 ### Logging, monitoring and alerting
 
-TechOps will provide logging, monitoring and alerting for the GSP. We will work with teams to ensure that it is setup in the most useful way for teams. Specifically:
+TechOps will provide logging, monitoring and alerting for the GDS Supported Platform. We will work with teams to ensure that it is set up in the most useful way for teams. Specifically:
 
-RE will ship logs to CloudWatch for further distribution. These logs will include:
+RE will ship logs to CloudWatch for further distribution (for example, to Splunk).
 
-- [insert log types here]
+Cyber Security will then work with teams to establish use cases for their protective monitoring using Splunk. Splunk will alert service teams when their use cases are triggered. Playbooks will include helpful information as to how the service team should deal with a given situation.
 
-Cyber Security will then work with teams to establish use cases for the [Cloud Security Watch](#link) service that they provide. Cloud Security Watch will alert service teams when these use cases are triggered. This alert will include helpful information as to how the service team should deal with the situation.
+If the service team is unable to respond to the situation themselves or if it is categorised as a security incident, they should contact the Cyber Security team either on Slack or through the out-of-hours procedure, if necessary.
 
-If the service team is unable to respond to the situation themselves, they should contact the Cyber Security team either [on Slack](https://gds.slack.com/messages/CCMPJKFDK) or through the [out-of-hours procedure](#link), if necessary.
+Cyber Security will also provide access to Splunk. Service teams will then be able to use Splunk to maintain their current protective monitoring use cases and develop new ones over time.
 
-Cyber Security will also provide access to [Splunk](https://www.splunk.com/) and training for its use by service teams. Service teams will then be able to use Splunk for further monitoring.
+If, when dealing with service issues, security events/incidents, etc., service teams identify infrastructural issues, TechOps (RE or Cyber Security, depending on where the issue occurs) will work with the service team to resolve the issue.
 
-If, when dealing with service issues, security events/incidents, etc., service teams identify infrastructural issues, TechOps (RE or Cyber Security, depending on where the issue occurs) will work with the service team to rectify the issue.
+Due to the way in which applications are deployed and the production of logs occurs, TechOps will not be responsible for the structuring of logs or consistent identification of log streams (see Logging section in Product team responsibilities below).
 
-Due to the way in which applications are deployed and the production of logs occurs, TechOps will not be responsible for the structuring of logs or consistent identification of log streams (see *Logging* section in *Product team responsibilities* below).
+TechOps will provide:
 
-TechOps will provide monitoring, using [Prometheus](), and alerting, using [AlertManager]() and [PagerDuty]().
+- health and reliability monitoring using [Prometheus](https://prometheus.io/)
+- alerting using [Prometheus' AlertManager](https://prometheus.io/docs/alerting/alertmanager/) and [PagerDuty](https://www.pagerduty.com/).
 
-TechOps will work with teams to identify the most valuable things to monitor and alert on (including the above Cloud Security Watch offering) and then to implement the correct logging, monitoring and alerting to facilitate this.
+TechOps will work with teams to identify the most valuable things to monitor and alert on (including the above protective monitoring offering) and then work together to implement the correct logging, monitoring and alerting to facilitate this.
 
-TechOps will setup monitoring and alerting to ensure that we provide reliable and secure infrastructure, in line with our [Service Level Objectives]().
+TechOps will set up health and reliability monitoring and alerting to ensure that we provide reliable and secure infrastructure, in line with our service level objectives (SLOs).
 
-[I think maybe this needs to be split out into separate "logging" and "monitoring and alerting" sections, but I don't know how...]
+### Ensuring the integrity of deployments
 
-### Cyber Security and acting on vulnerabilities
+TechOps will provide tooling and enforcement of measures that ensure that the right code gets deployed to production in the right way.
 
-Reliability Engineering will monitor [CVEs](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) that relate to the technologies that underpin the infrastructure that we provide. We will then mitigate any identified vulnerabilities with [THIS PERIOD OF TIME].
+Specifically, TechOps will enforce the established best practice of "two-eyes" (having at least two people look at the code before it is merged to the master branch of a repository), which will mean that no deployments can be made without being reviewed and signed by at least two authorised people.
 
-Cyber Security will provide tooling and advice to teams, in order that they can identify and act upon security events and incidents. Tooling includes [Cloud Security Watch](https://github.com/alphagov/csw-infra) and [Splunk](https://www.splunk.com/). Advice includes working with teams to identify possible vulnerabilities that need to be monitored for exploitation, and then helping to set up that monitoring/alerting.
+### Responding to security events and incidents and acting on vulnerabilities
+
+Reliability Engineering (RE) will monitor CVEs that relate to the technologies that underpin the infrastructure that we provide. RE will then work to mitigate any identified vulnerabilities that affect the platform as quickly as possible.
+
+Cyber Security will provide tooling and advice to teams, in order that they can identify and act upon security events and incidents.
+
+Tooling includes:
+
+- [Cloud Security Watch](https://github.com/alphagov/csw-backend), a tool to detect misconfigurations in AWS
+- [Splunk](https://www.splunk.com/), a security information and event management [(SIEM)](https://en.wikipedia.org/wiki/Security_information_and_event_management) tool to enable protective monitoring
+
+Advice includes:
+
+- working with teams to conduct [threat modelling](https://www.owasp.org/index.php/Category:Threat_Modeling)
+- working with teams to identify use cases to mitigate risks that need to be protectively monitored
+- supporting teams to ingest data sources to Splunk
+- helping to set up protective monitoring and alerting
 
 ### User management
 
-TechOps will control access to the underlying infrastructure using [AWS]() [IAM roles](). [some other stuff here]
+TechOps will control access to the underlying infrastructure using AWS IAM roles. TechOps is therefore responsible for allowing and removing this access in a timely manner.
+
+All changes to user access and to the platform go through a two-eyes process to ensure a robust and secure approach to user access control.
 
 ## Product team responsibilities
 
@@ -60,45 +110,37 @@ TechOps will control access to the underlying infrastructure using [AWS]() [IAM 
 
 Product teams will be responsible for any updates/upgrades to the application and any upstream dependencies (such as libraries and packages).
 
-TechOps will, however, make this as easy as possible to implement, as changes such as these can be made live by making the changes in the code base before merging them to the master branch of the repository.
+TechOps will, however, make this as easy as possible to implement, as changes such as these can be put into production by making the changes in the code base before merging them to the master branch of the repository.
+
+### Setting up and maintaining a build/deploy pipeline
+
+Product teams will need to work with TechOps to set up the initial pipeline, including learning (through documentation that TechOps provide and through working together) how to do so themselves.
+
+Once the initial pipeline is established, the product team will be responsible for making sure that tests and so forth are maintained as the application(s) develop(s).
+
+Product teams are responsible for monitoring their pipelines for successful or failing jobs and acting upon that information.
 
 ### Logging
 
-Product teams are responsible for ensuring that they configure their applications and Docker images to ship logs [link to guidance?].
+Product teams are responsible for ensuring that they configure their applications and Docker images to ship logs.
 
-They must also ensure that their logs have a sensible and logical structure, to make them easy to identify and filter. For example:
+TechOps will develop guidance on logging in the near future. Refer to the [Splunk guidelines](http://dev.splunk.com/view/logging/SP-CAAAFCK) for now.
 
-[insert example of logically structured logs or link to guidance]
+Some brief examples can be seen on the [Splunk website](http://dev.splunk.com/view/logging/SP-CAAAFCM).
 
-Similarly, product teams must name their containers sensibly and logically for consistent identification of log streams. For example:
-
-[insert example of logically named containers or link to guidance]
+Similarly, product teams must name their containers sensibly and logically for consistent identification of log streams. Again, we will provide more detailed guidance soon.
 
 ### Monitoring and responding to alerts
 
-It is the product team's responsibility to monitor their product/service (using tooling provided by TechOps - see above) and to respond to both monitoring and alerts as required.
+It is the product team's responsibility to monitor their product/service (using tooling provided by TechOps - see above) and to respond to both monitoring and alerts as required. If the product team is unable to respond to the situation themselves or if it is categorised as a security incident, they should contact the Cyber Security team either on Slack or through the out-of-hours procedure, if necessary.
 
-The product team is also expected to allocate time to defining Service Level Indicators (SLIs) and Objectives (SLOs), in order that we can collectively setup the correct monitoring and alerting.
+Product teams are responsible for the development, maintenance and engineering of their use cases in Splunk. As their products develop, they should ensure their protective monitoring stays effective and relevant. Cyber Security will support teams where required.
+
+The product team is also expected to allocate time to defining service level indicators (SLIs) and objectives (SLOs), in order that we can collectively set up the correct monitoring and alerting.
 
 ### User management
 
-You must ensure that you control access to GitHub. As any code that is merged to the master branch of a repository will automatically be deployed, it is vital that only [trusted individuals](link to GDS Way bit about SC clearance and stuff) are able to merge pull requests.
-
-### [What of the following (if any) will we do vs. what the service team should do?]
-
-You must secure your AWS infrastructure. For example:
-
-* control egress traffic by [implementing VPC egress controls](https://aws.amazon.com/answers/networking/controlling-vpc-egress-traffic/)
-* use [TLS and other secure protocols](https://www.ncsc.gov.uk/guidance/tls-external-facing-services) to protect data
-* use secure coding practices like peer review
-* secure developer machines - ask the GDS IT team for guidance
-* manage secrets to [secure the build and deployment pipeline](https://www.ncsc.gov.uk/guidance/secure-build-and-deployment-pipeline)
-* control access to provisioned machines and other AWS services
-* implement protective monitoring and [logging for security purposes](https://www.ncsc.gov.uk/guidance/introduction-logging-security-purposes)
-* use [security hardening for VMs](https://gds-way.cloudapps.digital/standards/operating-systems.html)
-* enabling infrastructure monitoring using [AWS CloudWatch](https://aws.amazon.com/cloudwatch/)
-
-You must [transfer ownership](https://github.com/alphagov/re-build-systems/blob/master/examples/gds_specific_dns_and_jenkins/README.md#provision-the-main-jenkins-infrastructure) of the OAuth app to the [GitHub alphagov organisation](https://github.com/alphagov) once you have provisioned Jenkins. This prevents unauthorised access to the build system if the owner of the OAuth app leaves GDS.
+Product teams must ensure that they control access to GitHub. As any code that is merged to the master branch of a repository will automatically be deployed, it is vital that only trusted individuals are able to merge pull requests.
 
 ## Third party responsibilities
 
@@ -110,6 +152,10 @@ Amazon maintains the AWS infrastructure and is responsible for updating it. Reli
 
 ### Docker.io
 
-When you provision or reprovision your infrastructure you use the latest version of Docker. Docker is responsible for the maintenance and support of new and current versions.
 
-### [any others explicitly?]
+
+[What's the escalation path for when the inevitable arguments happen?]
+[something probably needs to go in here about Zendesk?]
+See Cyber Security’s page for more information about protective monitoring, our tools and services [link to more detailed guidance?]().
+[insert log types]
+[link to out of hours procedure]

--- a/docs/gsp-shared-responsiblity-model.md
+++ b/docs/gsp-shared-responsiblity-model.md
@@ -2,7 +2,7 @@
 
 TechOps (including Reliability Engineering, Cyber Security and User Support) uses a [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/) to provide a supported platform to GDS product teams. Broadly, TechOps builds, runs and maintains the infrastructure and supporting services, while the product teams maintain the applications that they wish to run on the platform.
 
-TechOps is only responsible for internal GDS product teams who host their service on the [GDS Supported Platform](https://github.com/alphagov/gsp-team-manual) and the [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk/).
+TechOps is only responsible for internal GDS product teams who host their service on the [GDS Supported Platform](https://github.com/alphagov/gsp-team-manual) and the [GOV.UK Platform as a Service (PaaS)](https://www.cloud.service.gov.uk/) and its tenants.
 
 ## Summary of responsibilities
 
@@ -33,7 +33,7 @@ Contact Cyber Security using the [#cyber-security-help](https://gds.slack.com/me
 
 ### Provisioning Amazon Web Services (AWS) accounts and infrastructure
 
-When a team has decided to use the GDS Supported Platform for hosting their application or service, Reliability Engineering (RE) will create an AWS account for the team (unless one exists for their wider programme, for example, GOV.UK or GOV.UK Verify) and provision the underlying infrastructure for teams to deploy their app.
+When a team has decided to use the GDS Supported Platform for hosting their application or service, Reliability Engineering (RE) will create an [AWS account for the team](https://reliability-engineering.cloudapps.digital/iaas.html#create-aws-accounts) (unless one exists for their wider programme, for example, GOV.UK or GOV.UK Verify) and provision the underlying infrastructure for teams to deploy their app.
 
 ### Updates and upgrades
 
@@ -51,11 +51,11 @@ RE is also responsible for providing tooling to monitor the pipeline, for exampl
 
 ### Logging, monitoring and alerting
 
-TechOps will provide logging, monitoring and alerting for the GDS Supported Platform. We will work with teams to ensure that it is set up in the most useful way for teams. Specifically:
+TechOps will provide logging, monitoring and alerting for the GDS Supported Platform. We will work with teams to ensure that it is set up in the most useful way for teams.
 
 RE will ship logs to CloudWatch for further distribution (for example, to Splunk).
 
-Cyber Security will then work with teams to establish use cases for their protective monitoring using Splunk. Splunk will alert service teams when their use cases are triggered. Playbooks will include helpful information as to how the service team should deal with a given situation.
+Cyber Security will then work with teams to establish use cases for teams' protective monitoring using Splunk. Splunk will alert service teams when those use cases are triggered. Playbooks will include helpful information as to how the service team should deal with a given situation.
 
 If the service team is unable to respond to the situation themselves or if it is categorised as a security incident, they should contact the Cyber Security team either on Slack or through the out-of-hours procedure, if necessary.
 
@@ -70,7 +70,7 @@ TechOps will provide:
 - health and reliability monitoring using [Prometheus](https://prometheus.io/)
 - alerting using [Prometheus' AlertManager](https://prometheus.io/docs/alerting/alertmanager/) and [PagerDuty](https://www.pagerduty.com/).
 
-TechOps will work with teams to identify the most valuable things to monitor and alert on (including the above protective monitoring offering) and then work together to implement the correct logging, monitoring and alerting to facilitate this.
+TechOps will work with teams to identify the most valuable things to monitor and alert on (including the protective monitoring offering) and then work together to implement the correct logging, monitoring and alerting to facilitate this.
 
 TechOps will set up health and reliability monitoring and alerting to ensure that we provide reliable and secure infrastructure, in line with our service level objectives (SLOs).
 
@@ -114,9 +114,9 @@ TechOps will, however, make this as easy as possible to implement, as changes su
 
 ### Setting up and maintaining a build/deploy pipeline
 
-Product teams will need to work with TechOps to set up the initial pipeline, including learning (through documentation that TechOps provide and through working together) how to do so themselves.
+Product teams will need to work with TechOps to set up the initial pipeline, including learning (through documentation that TechOps provides and through working together) how to do so themselves.
 
-Once the initial pipeline is established, the product team will be responsible for making sure that tests and so forth are maintained as the application(s) develop(s).
+Once the initial pipeline is established, the product team will be responsible for making sure that tests and specific procedures (for example. linting, formatting, promoting) are maintained as the application(s) develop(s).
 
 Product teams are responsible for monitoring their pipelines for successful or failing jobs and acting upon that information.
 
@@ -132,11 +132,11 @@ Similarly, product teams must name their containers sensibly and logically for c
 
 ### Monitoring and responding to alerts
 
-It is the product team's responsibility to monitor their product/service (using tooling provided by TechOps - see above) and to respond to both monitoring and alerts as required. If the product team is unable to respond to the situation themselves or if it is categorised as a security incident, they should contact the Cyber Security team either on Slack or through the out-of-hours procedure, if necessary.
+It is the product team's responsibility to monitor their product/service (using tooling provided by TechOps) and to respond to both monitoring and alerts as required. If the product team is unable to respond to the situation themselves or if it is categorised as a security incident, they should contact the Cyber Security team either on Slack or through the out-of-hours procedure, if necessary.
 
 Product teams are responsible for the development, maintenance and engineering of their use cases in Splunk. As their products develop, they should ensure their protective monitoring stays effective and relevant. Cyber Security will support teams where required.
 
-The product team is also expected to allocate time to defining service level indicators (SLIs) and objectives (SLOs), in order that we can collectively set up the correct monitoring and alerting.
+The product team is also expected to allocate time to defining service level indicators (SLIs) and objectives (SLOs), so that we can collectively set up the correct monitoring and alerting.
 
 ### User management
 


### PR DESCRIPTION
First draft of shared responsibility document, based on the one used
for the re-build-systems Jenkins repo. Needs consultation with
Cyber Security team and User Support for accuracy of shared
responsibilities. Also needs technical writer input.